### PR TITLE
Add some missing intructions in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,18 +4,20 @@ A FastAPI-powered backend for an e-commerce admin dashboard providing sales anal
 
 ## Development Requirements
 
-- Docker
 - Python 3.11+
+- Poetry
+- Docker
 
 ## Installation
 
 ```sh
+make generate_dot_env (For quick setup, you can skip this step and use `cp .env.example .env`)
 docker-compose build --no-cache
 docker-compose up
 make migrate
+make demo_data
 make lint
 make test
-make demo_data
 ```
 
 ## Running linting


### PR DESCRIPTION
## Problem  
The README.md installation instructions were missing two helpful setup commands for new developers.

## Solution  
Updated README.md to include:  
1. `make generate_dot_env` with a note about the shortcut option  
2. `make demo_data` command to populate test data  

## Is this PR safe to revert?  
✅ Yes - Only documentation changes were made  

## Does this PR introduce backwards incompatible changes?  
❌ No  

## Checklist  

- [x] I made a self-review and the PR is ready  
- [x] Manually tested and the code works as expected  
- [x] Documentation has been included/updated  

## Testing  
### Description  
1. Follow the new README instructions  
2. Verify both commands work:  
   ```bash  
   make generate_dot_env  
   make demo_data  
   ```  

### Additional Considerations  
N/A - Only affects documentation  

## Dependent PRs  
None  